### PR TITLE
IE 11 support.

### DIFF
--- a/src/js/mr-image-drawer.js
+++ b/src/js/mr-image-drawer.js
@@ -9,16 +9,17 @@ app.directive('mrImageDrawer', function(){
         template: '<div ng-repeat="rect in rects" style="' +
             'position: absolute;' +
             'cursor: pointer;' +
-            'top:    {{ rect.y1 }}px;' +
-            'left:   {{ rect.x1 }}px;' +
-            'width:  {{ (rect.x2 - rect.x1)}}px;' +
-            'height: {{ (rect.y2 - rect.y1)}}px;' +
-            "border: {{ rect.stroke || 3 }}px solid {{ rect.color || '#F00' }};" +
-            "background-color: {{ increaseBrightness(rect.color || '#F00', '0.3') }}" +
             '"' +
-            "ng-style='rectStyle'" +
-            "ng-mouseenter=\"rectStyle = { 'background-color': increaseBrightness(rect.color || '#F00', '0.1') }\"" +
-            "ng-mouseout=\"rectStyle =   { 'background-color': increaseBrightness(rect.color || '#F00', '0.3' ) }\"" +
+            "ng-style=\"{ " +
+                "  top: rect.y1 + 'px', " +
+                "  left: rect.x1 + 'px', " +
+                "  width: (rect.x2 - rect.x1) + 'px', " +
+                "  height: (rect.y2 - rect.y1) + 'px', " +
+                "  border: (rect.stroke || 3) + 'px solid ' + (rect.color || '#F00'), " +
+                " 'background-color': increaseBrightness(rect.color || '#F00', '0.3') " +
+            "}\" " +
+            "ng-mouseenter=\"rectStyle = { 'background-color': increaseBrightness(rect.color || '#F00', '0.1') }\" " +
+            "ng-mouseout=\"rectStyle =   { 'background-color': increaseBrightness(rect.color || '#F00', '0.3' ) }\" " +
         '></div>',
         link: function(scope, element) {
 


### PR DESCRIPTION
`mrImageDrawer` was using angular expressions inside of the `style` attribute in it's template. These have been moved to an `ngStyle` attribute to support Internet Explorer. IE was not interpreting the expressions in the `style` attribute correctly.